### PR TITLE
qemux86.coffee: Change arch to i386

### DIFF
--- a/qemux86.coffee
+++ b/qemux86.coffee
@@ -4,7 +4,7 @@ deviceTypesCommon = require 'resin-device-types/common'
 module.exports =
 	slug: 'qemux86'
 	name: 'QEMU X86 32bit'
-	arch: 'amd64'
+	arch: 'i386'
 	state: 'experimental'
 
 	instructions: commonImg.instructions


### PR DESCRIPTION
Arch was wrongly set as amd64 - changing to i386 so that edison images could be used.

Connect to https://github.com/resin-os/resin-qemu/issues/2