### PR TITLE
autohat: Update to using the resin-cli 4.5.0 and add more tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Update tests/autohat - Fetching the new resin-cli and adding additional tests [Praneeth]
 * Update meta-resin [Florin]
 * Change .coffee to announce partition 1 now holds config.json and also introduce versioning (v1) [Florin]
 

--- a/tests/start.sh
+++ b/tests/start.sh
@@ -22,12 +22,14 @@ trap 'cleanup fail' SIGINT SIGTERM
 if [ "${MACHINE}" == "qemux86-64" ]; then
 	echo "==============Running tests==============="
 	docker run --rm -v ${WORKSPACE}/tests/autohat:/autohat --privileged \
+		-v /dev/:/dev2 \
 		--env RESINRC_RESIN_URL=${RESINRC_RESIN_URL} \
 		--env email=${RESIN_EMAIL} \
 		--env password=${RESIN_PASSWORD} \
 		--env device_type=${MACHINE} \
 		--env application_name=${MACHINE//-} \
 		--env image=/autohat/resin.img \
+		--privileged \
 		$AUTOHAT_IMAGE robot --exitonerror -d /autohat /autohat/qemux86-64.robot
 fi
 trap 'cleanup' EXIT


### PR DESCRIPTION
Connects to #19 

Changes to the test framework - 

- Upgrade Resin CLI used to 4.5.0 [Praneeth]
- Add test case that verifies backup files [Horia]
- Add testcase for checking that loading a random kernel module works in a container [Tomás]
- Add test case that gets the host OS version of the image [Horia]
- Add new test for checking if md5sum of the host OS changed compared to fingerprint file [Horia]
- Change the default application pushed ondevice to autohat-ondevice [Praneeth]
- Add support pushing a specific commit to the Push Keyword [Praneeth]
- Add new test for checking if host OS version of the image is same via resin cli [Horia]
- Add new test for checking application environment variable [Horia]
- Fixed CLI version to 4.2 [Horia]
- Add support for devices without KVM virtualization [Tomás]