### PR TITLE
Force libsdl native being used 1.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Make Yocto use libsdl-native instead of host libsdl [Florin]
 * Update tests/start.sh - Adding new tests + fixes [Horia]
 * Update resin-yocto-scripts to master [Will]
 * Update tests/autohat to master [Will]

--- a/layers/meta-resin-qemu/conf/samples/local.conf.sample
+++ b/layers/meta-resin-qemu/conf/samples/local.conf.sample
@@ -61,6 +61,5 @@ BB_DISKMON_DIRS = "\
 # libsdl library available on your build system.
 PACKAGECONFIG_append_pn-qemu-native = " sdl"
 PACKAGECONFIG_append_pn-nativesdk-qemu = " sdl"
-ASSUME_PROVIDED += "libsdl-native"
 
 CONF_VERSION = "1"


### PR DESCRIPTION
Fixes https://github.com/resin-os/resinos/issues/346