### PR TITLE
running instructions: remove unsuitable `-cpu host` from non-KVM case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Change log
 -----------
 
+* Update running instructions for non-KVM case [Gergely]
+
 # v2.9.6+rev1
 ## (2018-01-13)
 

--- a/qemux86-64.coffee
+++ b/qemux86-64.coffee
@@ -10,7 +10,7 @@ QEMU_RUNNING_INSTRUCTIONS = '''
 	<br>
 	On systems without KVM support:
 	<br>
-	<code>qemu-system-x86_64 -drive file=resin-image-qemux86-64.img,media=disk,cache=none,format=raw -net nic,model=virtio -net user -m 512 -nographic -machine type=pc -smp 4 -cpu host</code>
+	<code>qemu-system-x86_64 -drive file=resin-image-qemux86-64.img,media=disk,cache=none,format=raw -net nic,model=virtio -net user -m 512 -nographic -machine type=pc -smp 4</code>
 	<br>
 	Tweak <code>-smp</code> and <code>-cpu</code> parameters based on the CPU of the machine qemu is running on. <code>-cpu</code> parameter needs to be dropped on OSX and Windows.
 	<br>

--- a/qemux86.coffee
+++ b/qemux86.coffee
@@ -10,7 +10,7 @@ QEMU_RUNNING_INSTRUCTIONS = '''
 	<br>
 	On systems without KVM support:
 	<br>
-	<code>qemu-system-i386 -drive file=resin-image-qemux86.img,media=disk,cache=none,format=raw -net nic,model=virtio -net user -m 512 -nographic -machine type=pc -smp 4 -cpu host</code>
+	<code>qemu-system-i386 -drive file=resin-image-qemux86.img,media=disk,cache=none,format=raw -net nic,model=virtio -net user -m 512 -nographic -machine type=pc -smp 4</code>
 	<br>
 	Tweak <code>-smp</code> and <code>-cpu</code> parameters based on the CPU of the machine qemu is running on. <code>-cpu</code> parameter needs to be dropped on OSX and Windows.
 	<br>


### PR DESCRIPTION
`-cpu host` setting is only available in KVM mode, as it can be
verified running `qemu-system-i386 -cpu help`, which says:

> host  KVM processor with all supported host features (only available in KVM mode)

Removing the `-cpu` setting seems to run fine as tested on non-KVM system.

Change-type: patch
Signed-off-by: Gergely Imreh <imrehg@gmail.com>